### PR TITLE
Improved logic of ip. Now it works on WSL also

### DIFF
--- a/lamx
+++ b/lamx
@@ -179,7 +179,7 @@ show_system_info() {
     echo "CPU: $(lscpu | grep 'Model name' | awk -F: '{print $2}' | xargs)"
     echo "RAM: $(free -h | awk '/Mem:/ {print $2" total, "$3" used, "$4" free"}')"
     echo "Disk: $(df -h / | awk 'NR==2{print $2" total, "$3" used, "$4" free"}')"
-    echo "IP: $(hostname -I | awk '{print $1}')"
+    echo "IP: $(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')"
     echo ""
     read -rp "Press Enter to return to main menu..."
     main_menu


### PR DESCRIPTION
The old command hostname -I doesn't work on some distros of wsl . But the new approach works
